### PR TITLE
Prevent flicker when hovering over child elements

### DIFF
--- a/html5tooltips.js
+++ b/html5tooltips.js
@@ -517,14 +517,14 @@ function tieTooltips()
 
     tModel.targetElements.forEach(function(el) {
       destrStack.push(function(){
-        el.removeEventListener("mouseover",targetMousemove);
-        el.removeEventListener("mouseout",targetMouseout);
+        el.removeEventListener("mouseenter",targetMousemove);
+        el.removeEventListener("mouseleave",targetMouseout);
         el.removeEventListener("focus",targetFocus);
         el.removeEventListener("blur",targetBlur);
       });
 
-      el.addEventListener("mouseover",targetMousemove);
-      el.addEventListener("mouseout",targetMouseout);
+      el.addEventListener("mouseenter",targetMousemove);
+      el.addEventListener("mouseleave",targetMouseout);
       el.addEventListener("focus",targetFocus);
       el.addEventListener("blur",targetBlur);
     });


### PR DESCRIPTION
Respond to the mouseenter/mouseleave events instead of mouseover/
mouseout to prevent event bubbling. The bubbling was causing the tooltip
animation to restart unexpectedly, creating a "flickering" effect as you
hover around within a tooltip-enabled element.

Check out these demos for some visual clarification:
https://github.com/NimbleNotes/html5tooltips-flicker-issue

And another resource (not using this library) that shows off the mouse event functionality: http://bl.ocks.org/mbostock/5247027

If this is currently the intended behavior, then maybe there is a way this library can be configured to use the new set of mouse events? Personally, I'm not sure if there are any other implications. From the light research I did it seems these new events were created in response to this sort of issue, and otherwise behave the same. 
