### PR TITLE
Added "moveTooltip" to public API (Issue #19)

### DIFF
--- a/html5tooltips.js
+++ b/html5tooltips.js
@@ -509,6 +509,7 @@
     this.hide=hide;
     this.show=show;
     this.showMore=showMore;
+    this.moveTooltip=moveTooltip;
 
     component.publ.unmount = function(){
       resetTooltipPosition();


### PR DESCRIPTION
As explained on Issue #19, it would be useful to have "moveTooltip" exposed to the public API.