### PR TITLE
Fix for external libraries combination (eq mootools)

### DIFF
--- a/html5tooltips.js
+++ b/html5tooltips.js
@@ -169,8 +169,12 @@
     {
       clearTimeout(notifyTimeoutID[propName]);
       notifyTimeoutID[propName]=setTimeout(function(){
-        for(var i in modelObservers[propName])
-          modelObservers[propName][i](component.model[propName]);
+        for(var i in modelObservers[propName]) {
+          try {
+              modelObservers[propName][i](component.model[propName]);
+          } catch (e) {
+          }
+        }
 
         if(modelObservers[''])
           for(var i in modelObservers[''])


### PR DESCRIPTION
Hi,

I use html5tooltipsjs with MooTools and i got a lot of errors. I think mootools expands native elements (like array) with some functionality.
The problem is, you use setTimeout and therefore I can not catch the errors.

The only solution was a try catch in your notifyObservers.
it would be great if you would accept the patch.


The following errors occurred:

```
TypeError: null is not a function
    at Array.forEach (<anonymous>)
    at Function.forEach (mootools-core.js?lu=1508143687:33)
    at Array.each (mootools-core.js?lu=1508143687:40)
    at html5tooltips.js?update=1508143687:174
```
```
html5tooltips.js?update=1508143687:176 TypeError: Cannot read property 'apply' of undefined
    at mootools-core.js?lu=1508143687:51
    at Array.map (<anonymous>)
    at Array.invoke (mootools-core.js?lu=1508143687:51)
    at html5tooltips.js?update=1508143687:174
```

```
TypeError: Cannot read property 'length' of null
    at Array.combine (mootools-core.js?lu=1508143687:54)
    at html5tooltips.js?update=1508143687:174
```

I would be happy about a better solution, too :-)